### PR TITLE
Revert "updated for newer titanoboa versions"

### DIFF
--- a/boa_zksync/compiler_utils.py
+++ b/boa_zksync/compiler_utils.py
@@ -1,7 +1,7 @@
 import textwrap
 
 import vyper.ast as vy_ast
-from vyper.ast.parse import parse_to_ast
+from vyper.ast.utils import parse_to_ast
 from vyper.exceptions import InvalidType
 from vyper.semantics.analysis.utils import get_exact_type_from_node
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,11 @@ version = "0.0.2"
 description = "A Zksync plugin for the Titanoboa Vyper interpreter"
 license = { file = "LICENSE" }
 readme = "README.md"
-keywords = [
-    "ethereum",
-    "evm",
-    "smart contract",
-    "development",
-    "vyper",
-    "zksync",
-]
+keywords = ["ethereum", "evm", "smart contract", "development", "vyper", "zksync"]
 classifiers = ["Topic :: Software Development"]
 
-dependencies = ["titanoboa>=0.2.0"]
+# Requirements
+dependencies = ["titanoboa>=0.1,<0.2"]
 
 [project.optional-dependencies]
 forking-recommended = ["ujson"]


### PR DESCRIPTION
Temporarily reverts DanielSchiavini/titanoboa-zksync#4, as we need to first publish the plugin for vyper 0.3. See #1