### PR TITLE
use dict index to get value instead of guessing filename

### DIFF
--- a/boa_zksync/compile.py
+++ b/boa_zksync/compile.py
@@ -40,7 +40,8 @@ def compile_zksync(
         with open(filename) as file:
             source_code = file.read()
 
-    compile_output = output[filename.removeprefix("./")]
+    # remove prefix if exists:
+    compile_output, vyper_version, zkvyper_version = output.values()
     bytecode = to_bytes(compile_output.pop("bytecode"))
     return ZksyncCompilerData(
         contract_name, source_code, compiler_args, bytecode, **compile_output

--- a/boa_zksync/compile.py
+++ b/boa_zksync/compile.py
@@ -7,6 +7,7 @@ from tempfile import TemporaryDirectory
 
 from boa.rpc import to_bytes
 
+from boa_zksync.compiler_utils import get_contract_key
 from boa_zksync.types import ZksyncCompilerData
 
 
@@ -39,9 +40,8 @@ def compile_zksync(
     if source_code is None:
         with open(filename) as file:
             source_code = file.read()
-
-    # remove prefix if exists:
-    compile_output, vyper_version, zkvyper_version = output.values()
+    
+    compile_output = get_contract_key(output)
     bytecode = to_bytes(compile_output.pop("bytecode"))
     return ZksyncCompilerData(
         contract_name, source_code, compiler_args, bytecode, **compile_output

--- a/boa_zksync/compile.py
+++ b/boa_zksync/compile.py
@@ -7,7 +7,7 @@ from tempfile import TemporaryDirectory
 
 from boa.rpc import to_bytes
 
-from boa_zksync.compiler_utils import get_contract_key
+from boa_zksync.compiler_utils import get_compiler_output
 from boa_zksync.types import ZksyncCompilerData
 
 
@@ -41,7 +41,7 @@ def compile_zksync(
         with open(filename) as file:
             source_code = file.read()
     
-    compile_output = get_contract_key(output)
+    compile_output = get_compiler_output(output)
     bytecode = to_bytes(compile_output.pop("bytecode"))
     return ZksyncCompilerData(
         contract_name, source_code, compiler_args, bytecode, **compile_output

--- a/boa_zksync/compiler_utils.py
+++ b/boa_zksync/compiler_utils.py
@@ -73,3 +73,17 @@ def detect_expr_type(source_code, contract):
             except InvalidType:
                 pass
     return None
+
+
+def get_contract_key(output):
+    # we need this helper method to get the correct key containing compiler output
+    # from the compiler. Assuming key names could change and also assuming that the
+    # number of keys could change, this method breaks if any of that happens:
+    
+    excluded_keys = {"version", "zk_version"}
+    contract_keys = set(output.keys()) - excluded_keys
+    
+    if len(contract_keys) != 1:
+        raise ValueError(f"Expected exactly one contract key, found {len(contract_keys)}")
+    
+    return next(iter(contract_keys))

--- a/boa_zksync/compiler_utils.py
+++ b/boa_zksync/compiler_utils.py
@@ -75,7 +75,7 @@ def detect_expr_type(source_code, contract):
     return None
 
 
-def get_contract_key(output):
+def get_compiler_output(output):
     # we need this helper method to get the correct key containing compiler output
     # from the compiler. Assuming key names could change and also assuming that the
     # number of keys could change, this method breaks if any of that happens:
@@ -86,4 +86,4 @@ def get_contract_key(output):
     if len(contract_keys) != 1:
         raise ValueError(f"Expected exactly one contract key, found {len(contract_keys)}")
     
-    return next(iter(contract_keys))
+    return output[next(iter(contract_keys))]

--- a/tests/test_get_compiler_output.py
+++ b/tests/test_get_compiler_output.py
@@ -1,0 +1,39 @@
+import pytest
+
+from boa_zksync.compiler_utils import get_compiler_output
+
+
+def test_get_compiler_output():
+    
+    output_dict = {
+        "blabla": 123,
+        "zk_version": 456,
+        "version": 789,
+    }
+    
+    get_compiler_output(output_dict) == 123
+
+    
+def test_get_compiler_output_revert_too_many_keys():
+    
+    output_dict = {
+        "blabla": 123,
+        "zk_version": 456,
+        "version": 789,
+        "new_compiler_output_key": 101112,
+    }
+    
+    with pytest.raises(ValueError, match="Expected exactly one contract key, found 2"):
+        get_compiler_output(output_dict)
+        
+
+def test_get_compiler_output_revert_unexpected_key():
+    
+    output_dict = {
+        "blabla": 123,
+        "zk_versions": 456,
+        "version": 789,
+    }
+    
+    with pytest.raises(ValueError, match="Expected exactly one contract key, found 2"):
+        get_compiler_output(output_dict)


### PR DESCRIPTION
### What I did

The compiler output contains a key-value pair with three keys: compile output, vyper version and zkvyper version.

Currently the compile output used filename with the prefix of './' removed. this doesnt work if './'  is not in the prefix:

```
(venv) % python scripts/deploy_infra.py 
Traceback (most recent call last):
  ...
    contract_obj = boa.loads_partial(source_code=new_source, filename=contract_file)
  File ".../venv/lib/python3.10/site-packages/boa/interpret.py", line 163, in loads_partial
    data = compiler_data(source_code, name, deployer_class, **compiler_args)
  File ".../venv/lib/python3.10/site-packages/boa/interpret.py", line 110, in compiler_data
    return _disk_cache.caching_lookup(cache_key, func)
  File ".../venv/lib/python3.10/site-packages/boa/util/disk_cache.py", line 70, in caching_lookup
    res = func()
  File ".../venv/lib/python3.10/site-packages/boa/interpret.py", line 100, in func
    ret = deployer.create_compiler_data(
  File ".../venv/lib/python3.10/site-packages/boa_zksync/deployer.py", line 36, in create_compiler_data
    return compile_zksync_source(source_code, contract_name, compiler_args)
  File "...venv/lib/python3.10/site-packages/boa_zksync/compile.py", line 70, in compile_zksync_source
    return compile_zksync(name, filename, compiler_args, source_code)
  File ".../venv/lib/python3.10/site-packages/boa_zksync/compile.py", line 43, in compile_zksync
    compile_output = output[filename.removeprefix("./")]
KeyError: '/var/folders/w7/3c51j_5j2gq4n13mljt4rrb80000gn/T/tmp8ziczmee/VyperContract.vy'
```

### How I did it

I added a helper method to fetch the correct key, but then it also breaks if the other key names change or if the number of keys change.

### How to verify it

you can try to deloy curve stableswap infra on zksync here:

https://github.com/curvefi/stableswap-ng/blob/main/scripts/deploy_infra.py

you need to call `python scripts/deploy_infra.py` and that should cleanly deploy. ensure you have the right env keys (it will bork at first but you'll find the changes you need to do'.

### Description for the changelog

Fetch compiler output from stdout without guessing the path of the temp filename.

### Cute Animal Picture

![image](https://github.com/user-attachments/assets/c06f9aa3-6489-4672-9752-1338256d19f4)

