### PR TITLE
fix: deployment issue for production RPC

### DIFF
--- a/boa_zksync/types.py
+++ b/boa_zksync/types.py
@@ -260,6 +260,7 @@ class ZksyncComputation:
         """
         Finds the actual transaction computation, since zksync has system
         contract calls in the trace.
+        Note: The output has more data when running via the era test node.
         """
         to, sender = output["to"], output["from"]
 
@@ -270,7 +271,10 @@ class ZksyncComputation:
                 if trace["to"] == to and trace["from"] == sender:
                     return cls.from_call_trace(trace)
 
-        return _find(output["calls"])
+        if result := _find(output["calls"]):
+            return result
+        # in production mode the result is not always nested
+        return cls.from_call_trace(output)
 
     @property
     def is_success(self) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "titanoboa-zksync"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Zksync plugin for the Titanoboa Vyper interpreter"
 license = { file = "LICENSE" }
 readme = "README.md"
@@ -8,7 +8,7 @@ keywords = ["ethereum", "evm", "smart contract", "development", "vyper", "zksync
 classifiers = ["Topic :: Software Development"]
 
 # Requirements
-dependencies = ["titanoboa>=0.1,<0.2"]
+dependencies = ["titanoboa==0.1.10"]
 
 [project.optional-dependencies]
 forking-recommended = ["ujson"]

--- a/tests/test_computation.py
+++ b/tests/test_computation.py
@@ -13,25 +13,29 @@ def test_from_debug_trace_nested():
         "from": sender,
         "to": to,
         "output": boa.env.generate_address(),
-        "calls": [{
-            "from": boa.env.generate_address(),
-            "to": boa.env.generate_address(),
-            "output": boa.env.generate_address(),
-            "calls": [],
-            **_required_fields,
-        }, {
-            "from": sender,
-            "to": to,
-            "output": "0x" +result.hex(),
-            "calls": [],
-            **_required_fields,
-        }, {
-            "from": boa.env.generate_address(),
-            "to": boa.env.generate_address(),
-            "output": boa.env.generate_address(),
-            "calls": [],
-            **_required_fields,
-        }]
+        "calls": [
+            {
+                "from": boa.env.generate_address(),
+                "to": boa.env.generate_address(),
+                "output": boa.env.generate_address(),
+                "calls": [],
+                **_required_fields,
+            },
+            {
+                "from": sender,
+                "to": to,
+                "output": "0x" + result.hex(),
+                "calls": [],
+                **_required_fields,
+            },
+            {
+                "from": boa.env.generate_address(),
+                "to": boa.env.generate_address(),
+                "output": boa.env.generate_address(),
+                "calls": [],
+                **_required_fields,
+            },
+        ],
     }
     assert ZksyncComputation.from_debug_trace(output).output == result
 
@@ -43,7 +47,7 @@ def test_from_debug_trace_production_mode():
     output = {
         "from": boa.env.generate_address(),
         "to": boa.env.generate_address(),
-        "output": "0x" +result.hex(),
+        "output": "0x" + result.hex(),
         "calls": [],
         **_required_fields,
     }

--- a/tests/test_computation.py
+++ b/tests/test_computation.py
@@ -1,0 +1,50 @@
+import boa
+
+from boa_zksync.types import ZksyncComputation
+
+_required_fields = {"gas": "0x0", "value": "0x0", "input": "0x00", "gasUsed": "0x0"}
+
+
+def test_from_debug_trace_nested():
+    sender = boa.env.generate_address()
+    to = boa.env.generate_address()
+    result = boa.env.generate_address().canonical_address
+    output = {
+        "from": sender,
+        "to": to,
+        "output": boa.env.generate_address(),
+        "calls": [{
+            "from": boa.env.generate_address(),
+            "to": boa.env.generate_address(),
+            "output": boa.env.generate_address(),
+            "calls": [],
+            **_required_fields,
+        }, {
+            "from": sender,
+            "to": to,
+            "output": "0x" +result.hex(),
+            "calls": [],
+            **_required_fields,
+        }, {
+            "from": boa.env.generate_address(),
+            "to": boa.env.generate_address(),
+            "output": boa.env.generate_address(),
+            "calls": [],
+            **_required_fields,
+        }]
+    }
+    assert ZksyncComputation.from_debug_trace(output).output == result
+
+
+def test_from_debug_trace_production_mode():
+    # in production the real transaction output is directly in the result
+    # when running via the era test node, more contracts are actually included
+    result = boa.env.generate_address().canonical_address
+    output = {
+        "from": boa.env.generate_address(),
+        "to": boa.env.generate_address(),
+        "output": "0x" +result.hex(),
+        "calls": [],
+        **_required_fields,
+    }
+    assert ZksyncComputation.from_debug_trace(output).output == result

--- a/tests/test_get_compiler_output.py
+++ b/tests/test_get_compiler_output.py
@@ -31,7 +31,6 @@ def test_get_compiler_output_unexpected_key():
     output_dict = {"blabla": 123, "zk_versions": 456, "version": 789}
 
     with pytest.raises(
-        ValueError,
-        match="Expected exactly one contract key, found blabla, zk_versions",
+        ValueError, match="Expected exactly one contract key, found blabla, zk_versions"
     ):
         get_compiler_output(output_dict)

--- a/tests/test_sepolia.py
+++ b/tests/test_sepolia.py
@@ -4,6 +4,7 @@ from boa.rpc import EthereumRPC
 
 from boa_zksync import EraTestNode
 from boa_zksync.environment import ZERO_ADDRESS
+from boa_zksync.types import ZksyncComputation
 
 
 def test_dummy_contract(zksync_sepolia_fork):

--- a/tests/test_sepolia.py
+++ b/tests/test_sepolia.py
@@ -4,7 +4,6 @@ from boa.rpc import EthereumRPC
 
 from boa_zksync import EraTestNode
 from boa_zksync.environment import ZERO_ADDRESS
-from boa_zksync.types import ZksyncComputation
 
 
 def test_dummy_contract(zksync_sepolia_fork):


### PR DESCRIPTION
### What I did
Accept the result of the RPC if the call is not nested

### How to verify it
The metaregistry should be deployed properly with [this commit](https://github.com/curvefi/metaregistry/commit/aaa66170e938506aa1a73533b4450372bb8b3d7d)

### Description for the changelog
- Fix issue with deployment via production RPC

### Cute Animal Picture
![image](https://github.com/user-attachments/assets/ce28c8eb-7862-4f8e-b494-a64d3da0006a)
