### PR TITLE
chore: update package and dependency versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
             --silent --output /usr/local/bin/zkvyper && \
             chmod +x /usr/local/bin/zkvyper && \
             zkvyper --version
-          curl --location https://github.com/matter-labs/era-test-node/releases/download/v0.1.0-alpha.27/era_test_node-v0.1.0-alpha.27-x86_64-unknown-linux-gnu.tar.gz \
+          curl --location https://github.com/matter-labs/era-test-node/releases/download/v0.1.0-alpha.29/era_test_node-v0.1.0-alpha.29-x86_64-unknown-linux-gnu.tar.gz \
             --silent --output era_test_node.tar.gz && \
             tar --extract --file=era_test_node.tar.gz && \
             mv era_test_node /usr/local/bin/era_test_node && \

--- a/boa_zksync/util.py
+++ b/boa_zksync/util.py
@@ -58,7 +58,7 @@ def install_zkvyper_compiler(
 
 
 def install_era_test_node(
-    source="https://github.com/matter-labs/era-test-node/releases/download/v0.1.0-alpha.27/era_test_node-v0.1.0-alpha.27-x86_64-unknown-linux-gnu.tar.gz",  # noqa: E501
+    source="https://github.com/matter-labs/era-test-node/releases/download/v0.1.0-alpha.29/era_test_node-v0.1.0-alpha.29-x86_64-unknown-linux-gnu.tar.gz",  # noqa: E501
     destination="/usr/local/bin/era_test_node",
 ):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "titanoboa-zksync"
-version = "0.2.3"
+version = "0.2.4"
 description = "A Zksync plugin for the Titanoboa Vyper interpreter"
 license = { file = "LICENSE" }
 readme = "README.md"
@@ -17,7 +17,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "titanoboa @ git+https://github.com/vyperlang/titanoboa.git",
+    "titanoboa==0.2.4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### What I did
- update boa-zksync to 0.2.4
- update boa to 0.2.4
- update era-test-node to [alpha.29](https://github.com/matter-labs/era-test-node/releases/tag/v0.1.0-alpha.29)


### Cute Animal Picture
![image](https://github.com/user-attachments/assets/1d42262b-46f6-432e-b823-8a9a4a2ec17d)
