### PR TITLE
chore: update zkvyper and era test node

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,11 +28,11 @@ jobs:
 
           echo "Installing zkvyper and era_test_node"
           # Install zkvyper and era_test_node from binary repositories
-          curl --location https://raw.githubusercontent.com/matter-labs/zkvyper-bin/v1.5.6/linux-amd64/zkvyper-linux-amd64-musl-v1.5.6 \
+          curl --location https://raw.githubusercontent.com/matter-labs/zkvyper-bin/v1.5.7/linux-amd64/zkvyper-linux-amd64-musl-v1.5.7 \
             --silent --output /usr/local/bin/zkvyper && \
             chmod +x /usr/local/bin/zkvyper && \
             zkvyper --version
-          curl --location https://github.com/matter-labs/era-test-node/releases/download/v0.1.0-alpha.29/era_test_node-v0.1.0-alpha.29-x86_64-unknown-linux-gnu.tar.gz \
+          curl --location https://github.com/matter-labs/era-test-node/releases/download/v0.1.0-alpha.30/era_test_node-v0.1.0-alpha.30-x86_64-unknown-linux-gnu.tar.gz \
             --silent --output era_test_node.tar.gz && \
             tar --extract --file=era_test_node.tar.gz && \
             mv era_test_node /usr/local/bin/era_test_node && \

--- a/boa_zksync/compiler_utils.py
+++ b/boa_zksync/compiler_utils.py
@@ -85,6 +85,7 @@ def get_compiler_output(output):
         "zk_version",
         "__VYPER_MINIMAL_PROXY_CONTRACT",
         "project_metadata",
+        "extra_data",
     }
     contract_keys = set(output.keys()) - excluded_keys
 

--- a/boa_zksync/compiler_utils.py
+++ b/boa_zksync/compiler_utils.py
@@ -80,13 +80,7 @@ def get_compiler_output(output):
     # from the compiler. Assuming key names could change and also assuming that the
     # number of keys could change, this method breaks if any of that happens:
 
-    excluded_keys = {
-        "version",
-        "zk_version",
-        "__VYPER_MINIMAL_PROXY_CONTRACT",
-        "project_metadata",
-        "extra_data",
-    }
+    excluded_keys = {"version", "zk_version", "__VYPER_MINIMAL_PROXY_CONTRACT", "extra_data"}
     contract_keys = set(output.keys()) - excluded_keys
 
     if len(contract_keys) != 1:

--- a/boa_zksync/util.py
+++ b/boa_zksync/util.py
@@ -39,7 +39,7 @@ def stop_subprocess(proc: Popen[bytes]):
 
 
 def install_zkvyper_compiler(
-    source="https://raw.githubusercontent.com/matter-labs/zkvyper-bin/v1.5.6/linux-amd64/zkvyper-linux-amd64-musl-v1.5.6",  # noqa: E501
+    source="https://raw.githubusercontent.com/matter-labs/zkvyper-bin/v1.5.7/linux-amd64/zkvyper-linux-amd64-musl-v1.5.7",  # noqa: E501
     destination="/usr/local/bin/zkvyper",
 ):
     """
@@ -58,7 +58,7 @@ def install_zkvyper_compiler(
 
 
 def install_era_test_node(
-    source="https://github.com/matter-labs/era-test-node/releases/download/v0.1.0-alpha.29/era_test_node-v0.1.0-alpha.29-x86_64-unknown-linux-gnu.tar.gz",  # noqa: E501
+    source="https://github.com/matter-labs/era-test-node/releases/download/v0.1.0-alpha.30/era_test_node-v0.1.0-alpha.30-x86_64-unknown-linux-gnu.tar.gz",  # noqa: E501
     destination="/usr/local/bin/era_test_node",
 ):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "titanoboa-zksync"
-version = "0.2.6"
+version = "0.2.7"
 description = "A Zksync plugin for the Titanoboa Vyper interpreter"
 license = { file = "LICENSE" }
 readme = "README.md"


### PR DESCRIPTION
### What I did
- updated zkvyper to [v1.5.7](https://github.com/matter-labs/era-compiler-vyper/releases/tag/1.5.7)
- updated era test node to [alpha.30](https://github.com/matter-labs/era-test-node/releases/tag/v0.1.0-alpha.30)
- updated this package's version to 0.2.7

### Cute Animal Picture
![image](https://github.com/user-attachments/assets/4f4a36d2-c76e-4000-bcd8-2d6d0b6e38df)

