### PR TITLE
chore: update era test node

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
             --silent --output /usr/local/bin/zkvyper && \
             chmod +x /usr/local/bin/zkvyper && \
             zkvyper --version
-          curl --location https://github.com/matter-labs/era-test-node/releases/download/v0.1.0-alpha.30/era_test_node-v0.1.0-alpha.30-x86_64-unknown-linux-gnu.tar.gz \
+          curl --location https://github.com/matter-labs/era-test-node/releases/download/v0.1.0-alpha.32/era_test_node-v0.1.0-alpha.32-x86_64-unknown-linux-gnu.tar.gz \
             --silent --output era_test_node.tar.gz && \
             tar --extract --file=era_test_node.tar.gz && \
             mv era_test_node /usr/local/bin/era_test_node && \

--- a/boa_zksync/util.py
+++ b/boa_zksync/util.py
@@ -58,7 +58,7 @@ def install_zkvyper_compiler(
 
 
 def install_era_test_node(
-    source="https://github.com/matter-labs/era-test-node/releases/download/v0.1.0-alpha.30/era_test_node-v0.1.0-alpha.30-x86_64-unknown-linux-gnu.tar.gz",  # noqa: E501
+    source="https://github.com/matter-labs/era-test-node/releases/download/v0.1.0-alpha.32/era_test_node-v0.1.0-alpha.32-x86_64-unknown-linux-gnu.tar.gz",  # noqa: E501
     destination="/usr/local/bin/era_test_node",
 ):
     """


### PR DESCRIPTION
### What I did
Updated test node version to [alpha.32](https://github.com/matter-labs/era-test-node/releases/tag/v0.1.0-alpha.32)

### Cute Animal Picture
![image](https://github.com/user-attachments/assets/1c2f4468-827b-4573-80b5-efaad8a8fd69)
