### PR TITLE
fix: add missing fields for zkvyper version `>=1.5.8` and adapt tests for #41

### DIFF
--- a/boa_zksync/types.py
+++ b/boa_zksync/types.py
@@ -252,6 +252,11 @@ class ZksyncCompilerData:
     userdoc: Optional[dict] = None
     devdoc: Optional[dict] = None
 
+    # zkvyper>=1.5.8 fields
+    ir_json: Optional[dict] = None
+    ast: Optional[dict] = None
+    assembly: Optional[str] = None
+
     @cached_property
     def global_ctx(self):
         return self.vyper.global_ctx


### PR DESCRIPTION
### What I did

Related to issue #41

Running compilation on network `eravm` was creating issues with missing fields for `zkvyper>=1.5.8`. I checked the code and tried to fix the issue to newer version of zkvyper.

Missing fields:
- `ir_json`
- `ast`
- `assembly`


### How I did it

Running the following script before running all tests to check every versions

```bash
#bin/bash

# Install ZKVyper
echo "Installing ZKVyper"

# Get arg from command line or set stable one
VERSION="${1:-"1.5.7"}"

# Download and install ZKVyper
validate_url()
{
    wget --spider $1 >/dev/null 2>&1
    return $?
}

if validate_url "https://github.com/matter-labs/era-compiler-vyper/releases/download/$VERSION/zkvyper-linux-amd64-gnu-v$VERSION"
then
	wget https://github.com/matter-labs/era-compiler-vyper/releases/download/$VERSION/zkvyper-linux-amd64-gnu-v$VERSION -O zkvyper
else
	wget https://github.com/matter-labs/era-compiler-vyper/releases/download/$VERSION/zkvyper-linux-amd64-musl-v$VERSION -O zkvyper
fi
chmod u+x zkvyper 
sudo rm -rf /usr/local/bin/zkvyper
sudo mv zkvyper /usr/local/bin

# Check installation
zkvyper --version
```

`>=1.5.7` -> OK

Managed to make it work for 1.5.4 and 1.5.3 but to many inconsistencies in error message to keep something stable

### How to verify it

```bash
make test
```

### Description for the changelog

- Add missing fields to zkvyper>=1.5.8
- Adapt tests to new zkvyper version

Warning: test are passing for zkvyper>=1.5.7
Problem with previous version for ``test_boa_loads::test_stack_trace``

### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://wallpapers.com/images/featured/cute-animal-pictures-tscmynv1q1lo33f7.jpg)