### PR TITLE
release: 0.2.10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
 
           echo "Installing zkvyper and anvil-zksync"
           # Install zkvyper and anvil-zksync from binary repositories
-          curl --location https://raw.githubusercontent.com/matter-labs/zkvyper-bin/v1.5.7/linux-amd64/zkvyper-linux-amd64-musl-v1.5.7 \
+          curl --location https://raw.githubusercontent.com/matter-labs/zkvyper-bin/v1.5.10/linux-amd64/zkvyper-linux-amd64-musl-v1.5.10 \
             --silent --output /usr/local/bin/zkvyper && \
             chmod +x /usr/local/bin/zkvyper && \
             zkvyper --version

--- a/boa_zksync/contract.py
+++ b/boa_zksync/contract.py
@@ -4,10 +4,10 @@ from typing import TYPE_CHECKING, Optional
 
 from boa import Env
 from boa.contracts.abi.abi_contract import ABIContract, ABIFunction
+from boa.contracts.event_decoder import RawLogEntry
 from boa.contracts.vyper.vyper_contract import VyperContract
 from boa.rpc import to_bytes, to_int
 from boa.util.abi import Address
-from boa.contracts.event_decoder import RawLogEntry
 from cached_property import cached_property
 from vyper.semantics.analysis.base import VarInfo
 from vyper.semantics.types import HashMapT

--- a/boa_zksync/contract.py
+++ b/boa_zksync/contract.py
@@ -7,6 +7,7 @@ from boa.contracts.abi.abi_contract import ABIContract, ABIFunction
 from boa.contracts.vyper.vyper_contract import VyperContract
 from boa.rpc import to_bytes, to_int
 from boa.util.abi import Address
+from boa.contracts.event_decoder import RawLogEntry
 from cached_property import cached_property
 from vyper.semantics.analysis.base import VarInfo
 from vyper.semantics.types import HashMapT
@@ -71,6 +72,7 @@ class ZksyncContract(ABIContract):
         super().__init__(
             name=contract_name,
             abi=compiler_data.abi,
+            events=[item for item in compiler_data.abi if item.get("type") == "event"],
             functions=functions,
             address=address,
             filename=filename,
@@ -173,7 +175,7 @@ class ZksyncContract(ABIContract):
             index = to_int(log["logIndex"])
             topics = [to_int(topic) for topic in log["topics"]]
             data = to_bytes(log["data"])
-            event = (index, address.canonical_address, topics, data)
+            event = RawLogEntry(index, address.canonical_address, topics, data)
             ret.append(c.decode_log(event))
         return ret
 

--- a/boa_zksync/types.py
+++ b/boa_zksync/types.py
@@ -252,6 +252,11 @@ class ZksyncCompilerData:
     userdoc: Optional[dict] = None
     devdoc: Optional[dict] = None
 
+    # zkvyper>=1.5.10 fields
+    ir_json: Optional[dict] = None
+    ast: Optional[dict] = None
+    assembly: Optional[str] = None
+
     @cached_property
     def global_ctx(self):
         return self.vyper.global_ctx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "titanoboa-zksync"
-version = "0.2.9"
+version = "0.2.10"
 description = "A Zksync plugin for the Titanoboa Vyper interpreter"
 license = { file = "LICENSE" }
 readme = "README.md"
@@ -17,7 +17,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "titanoboa>=0.2.5",
+    "titanoboa>=0.2.6",
 ]
 
 [project.optional-dependencies]

--- a/tests/data/Counter.vy
+++ b/tests/data/Counter.vy
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# pragma version 0.4.0
+# pragma version 0.4.1
 
 number: public(uint256)
 

--- a/tests/test_boa_loads.py
+++ b/tests/test_boa_loads.py
@@ -139,16 +139,16 @@ def get_name_of(addr: HasName) -> String[32]:
     )
     assert isinstance(call_trace, TraceFrame)
     assert str(call_trace).split("\n") == [
-        f'[E] [21325] CallerContract.get_name_of(addr = "{called_addr}") <0x>',
-        "    [E] [19164] Unknown contract 0x000000000000000000000000000000000000800B.0x29f172ad",
+        f'[E] [21307] CallerContract.get_name_of(addr = "{called_addr}") <0x>',
+        "    [E] [19146] Unknown contract 0x000000000000000000000000000000000000800B.0x29f172ad",
         "        [1909] Unknown contract 0x000000000000000000000000000000000000800B.0x06bed036",
         "            [159] Unknown contract 0x0000000000000000000000000000000000008010.0x00000000",
         "        [395] Unknown contract 0x000000000000000000000000000000000000800B.0xa225efcb",
         "        [2226] Unknown contract 0x0000000000000000000000000000000000008002.0x4de2e468",
         "        [373] Unknown contract 0x000000000000000000000000000000000000800B.0xa851ae78",
         "        [398] Unknown contract 0x0000000000000000000000000000000000008004.0xe516761e",
-        "        [E] [2554] Unknown contract 0x0000000000000000000000000000000000008009.0xb47fade1",
-        f'            [E] [1365] CallerContract.get_name_of(addr = "{called_addr}") <0x>',
+        "        [E] [2536] Unknown contract 0x0000000000000000000000000000000000008009.0xb47fade1",
+        f'            [E] [1355] CallerContract.get_name_of(addr = "{called_addr}") <0x>',
         "                [E] [397] CalledContract.name() <0x>",
     ]
 
@@ -187,23 +187,23 @@ event Transfer:
 
 @deploy
 def __init__(supply: uint256):
-    log Transfer(empty(address), msg.sender, supply)
+    log Transfer(sender=empty(address), receiver=msg.sender, value=supply)
 
 @external
 def transfer(_to : address, _value : uint256) -> bool:
-    log Transfer(msg.sender, _to, _value)
+    log Transfer(sender=msg.sender, receiver=_to, value=_value)
     return True
 """
     contract = boa.loads(code, 100)
-    assert [str(e) for e in contract.get_logs()] == [
-        "Transfer(sender=0x0000000000000000000000000000000000000000, "
-        "receiver=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266, value=100)"
-    ]
+    assert (
+        str(contract.get_logs())
+        == "[Transfer(address=Address('0x588758d8a0Ad1162A6294f3C274753137E664aE0'), sender=Address('0x0000000000000000000000000000000000000000'), receiver=Address('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'), value=100)]"
+    )
 
     to = boa.env.generate_address()
     contract.transfer(to, 10)
     assert [str(e) for e in contract.get_logs()] == [
-        f"Transfer(sender={boa.env.eoa}, receiver={to}, value=10)"
+        f"Transfer(address=Address('0x588758d8a0Ad1162A6294f3C274753137E664aE0'), sender=Address('{boa.env.eoa}'), receiver=Address('{to}'), value=10)"
     ]
 
 

--- a/tests/test_boa_loads.py
+++ b/tests/test_boa_loads.py
@@ -195,16 +195,22 @@ def transfer(_to : address, _value : uint256) -> bool:
     return True
 """
     contract = boa.loads(code, 100)
-    assert (
-        str(contract.get_logs())
-        == "[Transfer(address=Address('0x588758d8a0Ad1162A6294f3C274753137E664aE0'), sender=Address('0x0000000000000000000000000000000000000000'), receiver=Address('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'), value=100)]"
+    expected_log = (
+        f"[Transfer(address=Address('{contract.address}'), "
+        f"sender=Address('0x0000000000000000000000000000000000000000'), "
+        f"receiver=Address('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'), "
+        f"value=100)]"
     )
+    assert str(contract.get_logs()) == expected_log
 
     to = boa.env.generate_address()
     contract.transfer(to, 10)
-    assert [str(e) for e in contract.get_logs()] == [
-        f"Transfer(address=Address('0x588758d8a0Ad1162A6294f3C274753137E664aE0'), sender=Address('{boa.env.eoa}'), receiver=Address('{to}'), value=10)"
-    ]
+    expected_transfer = (
+        f"Transfer(address=Address('{contract.address}'), "
+        f"sender=Address('{boa.env.eoa}'), "
+        f"receiver=Address('{to}'), value=10)"
+    )
+    assert [str(e) for e in contract.get_logs()] == [expected_transfer]
 
 
 def test_time(zksync_env):


### PR DESCRIPTION
### What I did

Fixed titanoboa-zksync for 0.2.6 of titanoboa.

- Added fields (sorry, this is the same as https://github.com/vyperlang/titanoboa-zksync/pull/42 but I only saw it after I fixed)
- Updated tests
- Updated event related code

### How I did it

This whole package could probably use a refactor to make it more resiliant. It shouldn't need updating every time a new boa package is relased.

### How to verify it

```
uv run pytest -nauto tests/ 
```

### Description for the changelog

- Updated titanoboa-zksync to work with 0.2.6 of titanoboa

### Cute Animal Picture

![image](https://github.com/user-attachments/assets/1eee9a87-376d-469c-a3aa-6f01d86d0d2f)

