### PR TITLE
fix - shutdown `anvil-zksync` zombies, review tests and fork method for latest `anvil-zksync`

### DIFF
--- a/boa_zksync/__init__.py
+++ b/boa_zksync/__init__.py
@@ -12,18 +12,16 @@ def set_zksync_env(url, explorer_url=None, nickname=None):
     """Sets the boa environment to a zkSync network environment."""
     boa.set_verifier(ZksyncExplorer(explorer_url))
     env = ZksyncEnv.from_url(url, nickname=nickname)
-    boa.set_env(env)
-    return env
+    return boa.set_env(env)
 
 
 def set_zksync_test_env(node_args=(), nickname=None):
     """Sets the boa environment to a local Anvil ZKsync test network."""
     anvil_rpc = AnvilZKsync(node_args=node_args)
     env = ZksyncEnv(rpc=anvil_rpc, nickname=nickname)
-    boa.set_env(env)
     # The AnvilZKsync instance created here will be automatically tracked.
     anvil_rpc.start()
-    return env
+    return boa.set_env(env)
 
 
 def set_zksync_fork(url, nickname=None, *args, **kwargs):
@@ -33,9 +31,7 @@ def set_zksync_fork(url, nickname=None, *args, **kwargs):
     env = ZksyncEnv.from_url(url, nickname=nickname)
     # @dev The anvil_zksync_node.start() is handled within ZksyncEnv.fork_rpc
     env.fork(url=url, *args, **kwargs)
-    boa.set_env(env)
-
-    return env
+    return boa.set_env(env)
 
 
 def set_zksync_browser_env(*args, **kwargs):
@@ -44,8 +40,7 @@ def set_zksync_browser_env(*args, **kwargs):
     from boa_zksync.browser import ZksyncBrowserEnv
 
     env = ZksyncBrowserEnv(*args, **kwargs)
-    boa.set_env(env)
-    return env
+    return boa.set_env(env)
 
 
 boa.set_zksync_env = set_zksync_env

--- a/boa_zksync/__init__.py
+++ b/boa_zksync/__init__.py
@@ -1,3 +1,6 @@
+import atexit
+from typing import Optional
+
 import boa
 from boa import get_verifier
 from boa.verifiers import VerificationResult
@@ -7,29 +10,98 @@ from boa_zksync.environment import ZksyncEnv
 from boa_zksync.node import AnvilZKsync
 from boa_zksync.verifiers import ZksyncExplorer
 
+# Module-level variable to track the currently active AnvilZKsync node
+_current_anvil_zksync_node: Optional[AnvilZKsync] = None
+
+
+@atexit.register
+def _stop_active_anvil_zksync_node():
+    """Helper function to stop the currently tracked AnvilZKsync node.
+
+    This function is registered to run at exit, ensuring that any active
+    AnvilZKsync node is stopped cleanly when the program exits.
+    """
+    import logging
+
+    global _current_anvil_zksync_node
+    if _current_anvil_zksync_node is not None:
+        logging.info("Stopping active AnvilZKsync node via boa_zksync global cleanup.")
+        _current_anvil_zksync_node.stop()
+        _current_anvil_zksync_node = None
+    else:
+        logging.debug("No active AnvilZKsync node to stop.")
+
 
 def set_zksync_env(url, explorer_url=None, nickname=None):
+    """Sets the boa environment to a zkSync network environment."""
     boa.set_verifier(ZksyncExplorer(explorer_url))
-    return boa.set_env(ZksyncEnv.from_url(url, nickname=nickname))
+    env = ZksyncEnv.from_url(url, nickname=nickname)
+    boa.set_env(env)
+
+    # Ensure any previously active AnvilZKsync is stopped
+    _stop_active_anvil_zksync_node()
+    return env
 
 
 def set_zksync_test_env(node_args=(), nickname=None):
-    return boa.set_env(
-        ZksyncEnv(rpc=AnvilZKsync(node_args=node_args), nickname=nickname)
-    )
+    """
+    Sets the boa environment to a local Anvil ZKsync test network.
+    Manages the AnvilZKsync subprocess lifecycle.
+    """
+    global _current_anvil_zksync_node
+
+    # Stop any previously active AnvilZKsync node before starting a new one
+    _stop_active_anvil_zksync_node()
+
+    anvil_rpc = AnvilZKsync(node_args=node_args)
+    env = ZksyncEnv(rpc=anvil_rpc, nickname=nickname)
+    boa.set_env(env)
+
+    # Start the new AnvilZKsync node and track it
+    anvil_rpc.start()
+    _current_anvil_zksync_node = anvil_rpc
+
+    return env
 
 
 def set_zksync_fork(url, nickname=None, *args, **kwargs):
+    """
+    Sets the boa environment to a forked zkSync network using a local AnvilZKsync node.
+    Manages the AnvilZKsync subprocess lifecycle.
+    """
+    global _current_anvil_zksync_node
+
+    # Stop any previously active AnvilZKsync node before starting a new one
+    _stop_active_anvil_zksync_node()
+
     env = ZksyncEnv.from_url(url, nickname=nickname)
+    # The fork() method internally creates an AnvilZKsync instance and sets it as env._rpc
     env.fork(*args, **kwargs)
-    return boa.set_env(env)
+    boa.set_env(env)
+
+    # Start the AnvilZKsync node created by fork() and track it
+    if isinstance(env._rpc, AnvilZKsync):
+        env._rpc.start()
+        _current_anvil_zksync_node = env._rpc
+    else:
+        # This case implies a non-AnvilZKsync RPC was used for forking,
+        # so ensure no AnvilZKsync is tracked.
+        _current_anvil_zksync_node = None
+
+    return env
 
 
 def set_zksync_browser_env(*args, **kwargs):
+    """Sets the boa environment to a zkSync browser environment."""
+    # Ensure any previously active AnvilZKsync is stopped
+    _stop_active_anvil_zksync_node()
+
     # import locally because jupyter is generally not installed
     from boa_zksync.browser import ZksyncBrowserEnv
 
-    return boa.set_env(ZksyncBrowserEnv(*args, **kwargs))
+    env = ZksyncBrowserEnv(*args, **kwargs)
+    boa.set_env(env)
+    return env
 
 
 boa.set_zksync_env = set_zksync_env

--- a/boa_zksync/__init__.py
+++ b/boa_zksync/__init__.py
@@ -1,6 +1,3 @@
-import atexit
-
-
 import boa
 from boa import get_verifier
 from boa.verifiers import VerificationResult
@@ -9,74 +6,6 @@ from boa_zksync.contract import ZksyncContract
 from boa_zksync.environment import ZksyncEnv
 from boa_zksync.node import AnvilZKsync
 from boa_zksync.verifiers import ZksyncExplorer
-
-from weakref import WeakSet
-
-# Using a WeakSet means instances are automatically removed when they are no longer
-# referenced elsewhere and garbage collected.
-_all_anvil_zksync_instances: WeakSet[AnvilZKsync] = WeakSet()
-
-# Temporary tracker for the currently active AnvilZKsync node.
-_original_anvil_zksync_new = AnvilZKsync.__new__
-
-
-def _new_anvil_zksync_instance(cls, *args, **kwargs):
-    """
-    Interceptor for AnvilZKsync.__new__ to track all created instances.
-    """
-    import logging
-
-    # Call the original __new__ to create the instance
-    instance = _original_anvil_zksync_new(cls)
-    # Add to our global tracking set
-    _all_anvil_zksync_instances.add(instance)
-    logging.debug(
-        f"AnvilZKsync instance created and added to global tracker: {instance}"
-    )
-    return instance
-
-
-# Replace AnvilZKsync's __new__ method with our interceptor
-AnvilZKsync.__new__ = _new_anvil_zksync_instance
-
-
-@atexit.register
-def _stop_all_active_anvil_zksync_nodes_on_exit():
-    """
-    Atexit handler to stop any AnvilZKsync nodes still running when the program exits.
-    This uses the global tracking set and checks for live processes.
-    """
-    import logging
-
-    if not _all_anvil_zksync_instances:
-        logging.debug("No AnvilZKsync instances were tracked during program execution.")
-        return
-
-    logging.info(
-        "Running atexit cleanup: Checking for remaining active AnvilZKsync nodes."
-    )
-    nodes_to_stop = []
-    # Iterate over a list copy to safely modify the WeakSet if items are removed by GC
-    for node in list(_all_anvil_zksync_instances):
-        # node._test_node is the Popen object. poll() returns None if still running.
-        if node._test_node and node._test_node.poll() is None:
-            nodes_to_stop.append(node)
-        else:
-            # If the process is already dead, the WeakSet will eventually remove it,
-            # but we can explicitly log that it's no longer active.
-            logging.debug(f"AnvilZKsync node {node} already terminated or not started.")
-
-    if nodes_to_stop:
-        logging.info(f"Stopping {len(nodes_to_stop)} remaining AnvilZKsync node(s).")
-        for node in nodes_to_stop:
-            try:
-                # Call the original stop method
-                node.stop()
-                logging.info(f"Successfully stopped AnvilZKsync node: {node}")
-            except Exception as e:
-                logging.error(f"Error stopping AnvilZKsync node {node}: {e}")
-    else:
-        logging.info("No active AnvilZKsync nodes found needing cleanup at exit.")
 
 
 def set_zksync_env(url, explorer_url=None, nickname=None):

--- a/boa_zksync/environment.py
+++ b/boa_zksync/environment.py
@@ -82,7 +82,7 @@ class ZksyncEnv(NetworkEnv):
         :param kwargs: Additional arguments for the RPC.
         """
         if url:
-            # @dev deprecated in boa, use boa.fork instead
+            # @dev deprecated in boa, use AnvilZKsync fork mode
             # return super().fork(url, reset_traces, block_identifier, debug, **kwargs)
             self.fork_rpc(EthereumRPC(url), reset_traces, block_identifier, **kwargs)
         else:
@@ -170,9 +170,9 @@ class ZksyncEnv(NetworkEnv):
                 tx_data, receipt, trace = self._send_txn(**args.as_tx_params())
                 self.last_receipt = receipt
                 if trace:
-                    assert (
-                        traced_computation.is_error == trace.is_error
-                    ), f"VMError mismatch: {traced_computation.error} != {trace.error}"
+                    assert traced_computation.is_error == trace.is_error, (
+                        f"VMError mismatch: {traced_computation.error} != {trace.error}"
+                    )
                     return ZksyncComputation.from_debug_trace(self, trace.raw_trace)
 
             except _EstimateGasFailed:

--- a/boa_zksync/environment.py
+++ b/boa_zksync/environment.py
@@ -5,7 +5,6 @@ from hashlib import sha256
 from pathlib import Path
 from typing import Any, Iterable, Optional, Type
 
-from boa import fork as boa_fork
 from boa.contracts.abi.abi_contract import ABIContract, ABIContractFactory
 from boa.deployments import get_deployments_db
 from boa.environment import _AddressType
@@ -74,11 +73,7 @@ class ZksyncEnv(NetworkEnv):
             self._rpc = inner_rpc
 
     def fork(
-        self,
-        url: str = None,
-        reset_traces=True,
-        block_identifier="safe",
-        **kwargs,
+        self, url: str = None, reset_traces=True, block_identifier="safe", **kwargs
     ):
         """Fork the environment to a local chain.
         :param url: The URL of the RPC to fork from.
@@ -89,12 +84,7 @@ class ZksyncEnv(NetworkEnv):
         if url:
             # @dev deprecated in boa, use boa.fork instead
             # return super().fork(url, reset_traces, block_identifier, debug, **kwargs)
-            self.fork_rpc(
-                EthereumRPC(url),
-                reset_traces,
-                block_identifier,
-                **kwargs,
-            )
+            self.fork_rpc(EthereumRPC(url), reset_traces, block_identifier, **kwargs)
         else:
             # This branch for forking from a pre-existing local Anvil
             self.fork_rpc(self._rpc, reset_traces, block_identifier, **kwargs)
@@ -118,9 +108,7 @@ class ZksyncEnv(NetworkEnv):
             self.sstore_trace: dict = {}
         # Create the new AnvilZKsync instance with the provided RPC and block identifier.
         new_anvil_rpc = AnvilZKsync(
-            inner_rpc=rpc,
-            block_identifier=block_identifier,
-            **kwargs,
+            inner_rpc=rpc, block_identifier=block_identifier, **kwargs
         )
         self._rpc = new_anvil_rpc
 
@@ -182,9 +170,9 @@ class ZksyncEnv(NetworkEnv):
                 tx_data, receipt, trace = self._send_txn(**args.as_tx_params())
                 self.last_receipt = receipt
                 if trace:
-                    assert traced_computation.is_error == trace.is_error, (
-                        f"VMError mismatch: {traced_computation.error} != {trace.error}"
-                    )
+                    assert (
+                        traced_computation.is_error == trace.is_error
+                    ), f"VMError mismatch: {traced_computation.error} != {trace.error}"
                     return ZksyncComputation.from_debug_trace(self, trace.raw_trace)
 
             except _EstimateGasFailed:

--- a/boa_zksync/environment.py
+++ b/boa_zksync/environment.py
@@ -89,7 +89,12 @@ class ZksyncEnv(NetworkEnv):
         if url:
             # @dev deprecated in boa, use boa.fork instead
             # return super().fork(url, reset_traces, block_identifier, debug, **kwargs)
-            boa_fork(url, reset_traces, block_identifier, **kwargs)
+            self.fork_rpc(
+                EthereumRPC(url),
+                reset_traces,
+                block_identifier,
+                **kwargs,
+            )
         else:
             # This branch for forking from a pre-existing local Anvil
             self.fork_rpc(self._rpc, reset_traces, block_identifier, **kwargs)

--- a/boa_zksync/environment.py
+++ b/boa_zksync/environment.py
@@ -89,10 +89,16 @@ class ZksyncEnv(NetworkEnv):
         :param block_identifier: Block identifier to fork from
         :param kwargs: Additional arguments for the RPC
         """
+        if isinstance(self._rpc, AnvilZKsync):
+            self._rpc.stop()
+
         self._reset_fork(block_identifier)
         if reset_traces:
             self.sha3_trace: dict = {}
             self.sstore_trace: dict = {}
+        # Create the new AnvilZKsync instance.
+        # @dev start() will be called by this ZksyncEnv's __enter__ method later,
+        # or by an external manager if ZksyncEnv is not used as a context.
         self._rpc = AnvilZKsync(rpc, block_identifier, **kwargs)
 
     def register_contract(self, address, obj):

--- a/boa_zksync/node.py
+++ b/boa_zksync/node.py
@@ -104,7 +104,7 @@ class AnvilZKsync(EthereumRPC):
             else []
         )
         command_base = (
-            ["fork", "--fork-url", self.inner_rpc] + fork_at_args
+            ["fork", "--fork-url", self.inner_rpc._rpc_url] + fork_at_args
             if self.inner_rpc
             else ["run"]
         )

--- a/boa_zksync/util.py
+++ b/boa_zksync/util.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import socket
 import warnings
@@ -17,6 +18,31 @@ def find_free_port():
     portnum = s.getsockname()[1]
     s.close()
     return portnum
+
+
+def is_port_free(port: int, host: str = "127.0.0.1") -> bool:
+    """
+    Checks if a specific port on a given host is free (available for binding).
+
+    :param port: The port number to check.
+    :param host: The host IP address (e.g., "127.0.0.1" for localhost).
+    :return: True if the port is free, False otherwise.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        s.bind((host, port))
+        return True
+    except OSError as e:
+        if e.errno == errno.EADDRINUSE:
+            # Port is already in use
+            return False
+        else:
+            # Re-raise unexpected errors
+            raise
+    finally:
+        # Close the socket
+        s.close()
 
 
 def wait_url(url: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,34 +12,24 @@ keywords = [
     "vyper",
     "zksync",
 ]
-classifiers = [
-    "Topic :: Software Development",
-]
+classifiers = ["Topic :: Software Development"]
 
 dependencies = [
     "titanoboa>=0.2.6",
-]
+    "vyper<0.4.2",
+] #@TODO to update when zkvyper adapted
 
 [project.optional-dependencies]
-forking-recommended = [
-    "ujson",
-]
+forking-recommended = ["ujson"]
 
 [build-system]
-requires = [
-    "setuptools",
-    "wheel",
-]
+requires = ["setuptools", "wheel"]
 
 [tool.setuptools.packages.find]
-include = [
-    "boa_zksync*",
-]
+include = ["boa_zksync*"]
 
 [tool.setuptools.package-data]
-boa_zksync = [
-    '*.json',
-]
+boa_zksync = ['*.json']
 
 [tool.uv]
 dev-dependencies = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,11 +30,10 @@ def zksync_env(account):
 @pytest.fixture(scope="module")
 def zksync_sepolia_fork(account):
     old_env = boa.env
+    # @dev removed node_args deprecated anvil-zksync argument
+    # @dev let block_identifier be "safe" by default
     boa_zksync.set_zksync_fork(
         ZKSYNC_SEPOLIA_RPC_URL,
-        block_identifier=3000000,
-        # @dev deprecated in anvil
-        # node_args=("--show-calls", "all", "--show-outputs", "true"),
     )
     boa.env.add_account(account, force_eoa=True)
     yield boa.env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ ZKSYNC_SEPOLIA_RPC_URL = os.getenv(
     "ZKSYNC_SEPOLIA_RPC_URL", "https://sepolia.era.zksync.dev"
 )
 ZKSYNC_SEPOLIA_EXPLORER_URL = os.getenv(
-    "ZKSYNC_SEPOLIA_EXPLORER_URL", "https://explorer.sepolia.era.zksync.dev"
+    "ZKSYNC_SEPOLIA_EXPLORER_URL", "https://sepolia.explorer.zksync.io"
 )
 
 
@@ -33,7 +33,8 @@ def zksync_sepolia_fork(account):
     boa_zksync.set_zksync_fork(
         ZKSYNC_SEPOLIA_RPC_URL,
         block_identifier=3000000,
-        node_args=("--show-calls", "all", "--show-outputs", "true"),
+        # @dev deprecated in anvil
+        # node_args=("--show-calls", "all", "--show-outputs", "true"),
     )
     boa.env.add_account(account, force_eoa=True)
     yield boa.env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,9 +32,7 @@ def zksync_sepolia_fork(account):
     old_env = boa.env
     # @dev removed node_args deprecated anvil-zksync argument
     # @dev let block_identifier be "safe" by default
-    boa_zksync.set_zksync_fork(
-        ZKSYNC_SEPOLIA_RPC_URL,
-    )
+    boa_zksync.set_zksync_fork(ZKSYNC_SEPOLIA_RPC_URL)
     boa.env.add_account(account, force_eoa=True)
     yield boa.env
     boa.set_env(old_env)

--- a/tests/test_boa_loads.py
+++ b/tests/test_boa_loads.py
@@ -131,7 +131,7 @@ def get_name_of(addr: HasName) -> String[32]:
             f"{caller_contract.address}> (file "
             "<unknown>).get_name_of(address) -> ['string'])",
             "   <Unknown contract 0x0000000000000000000000000000000000008009>",
-            "   <Unknown contract 0x000000000000000000000000000000000000800b>",
+            # "   <Unknown contract 0x000000000000000000000000000000000000800b>",
             "  Test an error(<CallerContract interface at "
             f"{caller_contract.address}> (file <unknown>).get_name_of(address) -> "
             "['string'])",
@@ -139,17 +139,17 @@ def get_name_of(addr: HasName) -> String[32]:
     )
     assert isinstance(call_trace, TraceFrame)
     assert str(call_trace).split("\n") == [
-        f'[E] [21307] CallerContract.get_name_of(addr = "{called_addr}") <0x>',
-        "    [E] [19146] Unknown contract 0x000000000000000000000000000000000000800B.0x29f172ad",
-        "        [1909] Unknown contract 0x000000000000000000000000000000000000800B.0x06bed036",
-        "            [159] Unknown contract 0x0000000000000000000000000000000000008010.0x00000000",
-        "        [395] Unknown contract 0x000000000000000000000000000000000000800B.0xa225efcb",
-        "        [2226] Unknown contract 0x0000000000000000000000000000000000008002.0x4de2e468",
-        "        [373] Unknown contract 0x000000000000000000000000000000000000800B.0xa851ae78",
-        "        [398] Unknown contract 0x0000000000000000000000000000000000008004.0xe516761e",
-        "        [E] [2536] Unknown contract 0x0000000000000000000000000000000000008009.0xb47fade1",
-        f'            [E] [1355] CallerContract.get_name_of(addr = "{called_addr}") <0x>',
-        "                [E] [397] CalledContract.name() <0x>",
+        f'[E] [20942] CallerContract.get_name_of(addr = "{called_addr}") <Test an error>',
+        "    [445] Unknown contract 0x000000000000000000000000000000000000800B.0x29f172ad",
+        "    [1891] Unknown contract 0x000000000000000000000000000000000000800B.0x06bed036",
+        "        [159] Unknown contract 0x0000000000000000000000000000000000008010.0x00000000",
+        "    [383] Unknown contract 0x000000000000000000000000000000000000800B.0xa225efcb",
+        "    [2202] Unknown contract 0x0000000000000000000000000000000000008002.0x4de2e468",
+        "    [355] Unknown contract 0x000000000000000000000000000000000000800B.0xa851ae78",
+        "    [458] Unknown contract 0x0000000000000000000000000000000000008004.0xe516761e",
+        "    [E] [2412] Unknown contract 0x0000000000000000000000000000000000008009.0xb47fade1",
+        f'        [E] [1347] CallerContract.get_name_of(addr = "{called_addr}") <0x>',
+        "            [E] [397] CalledContract.name() <0x>",
     ]
 
 


### PR DESCRIPTION
## Related issue: #45 

### What I did

The main goal was to kill the remaining `anvil-zksync` process, since they were not garbage collected. But I ended up adapting `boa-zksync` to the latest `anvil-zksync` and reviewed the fork system.

Key changes include the refactoring of environment setup functions, enhancements to the `AnvilZKsync` class for managing test nodes (lifecycle), and updates to dependencies and test configurations.

I tried at first to go for a context manager method inside `AnvilZKsync` but it was not adapted to our need, and it would have brought too many changes in other tools like Moccasin.

### How I did it

#### Improvements to `AnvilZKsync` test node management:
* Introduced a global `WeakSet` to track active `AnvilZKsync` instances and ensure proper cleanup using an `atexit` handler. (`boa_zksync/node.py`, [boa_zksync/node.pyR1-R31](diffhunk://#diff-5bf75c708abd8cc4f8a82f9ad06c42352e3d4dba681e9c2e90385adcea4eabc9R1-R31))
* Added dynamic port allocation logic to support parallel testing with `pytest-xdist` and fallback to a suggested port when available. (`boa_zksync/node.py`, [boa_zksync/node.pyR76-R221](diffhunk://#diff-5bf75c708abd8cc4f8a82f9ad06c42352e3d4dba681e9c2e90385adcea4eabc9R76-R221))
* Enhanced the node startup process with a `_build_command` method for constructing commands and improved error handling during node shutdown. (`boa_zksync/node.py`, [boa_zksync/node.pyR76-R221](diffhunk://#diff-5bf75c708abd8cc4f8a82f9ad06c42352e3d4dba681e9c2e90385adcea4eabc9R76-R221))

#### Enhancements to zkSync environment setup:
* Refactored functions like `set_zksync_env`, `set_zksync_test_env`, and `set_zksync_fork` to improve clarity and ensure consistent environment initialization. Added detailed docstrings for better documentation. (`boa_zksync/__init__.py`, [boa_zksync/__init__.pyR12-R48](diffhunk://#diff-bf71589a384779b9c95f8c5b04d8c180b3ec262a2231310346cbec61d537f476R12-R48))
* Deprecated the use of `node_args` in `set_zksync_fork` and updated the default behavior for `block_identifier`. (`tests/conftest.py`, [tests/conftest.pyL33-R35](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L33-R35))

#### Updates to forking and RPC handling:
* Modified the `fork` and `fork_rpc` methods to improve handling of RPC connections, ensure proper cleanup of existing nodes, and support new configurations. (`boa_zksync/environment.py`, [[1]](diffhunk://#diff-37942ab3cb622bc5b296491d77ac2c47c34c4fe054c0a4d0e725f823b1d50a33R78-R90) [[2]](diffhunk://#diff-37942ab3cb622bc5b296491d77ac2c47c34c4fe054c0a4d0e725f823b1d50a33R102-R116)
* Added a utility function `is_port_free` to check port availability, improving the robustness of test node setup. (`boa_zksync/util.py`, [boa_zksync/util.pyR23-R47](diffhunk://#diff-f0066a47d85c26db13379d0187ee52d50dd78799fc19ec1c97604e0a96694d82R23-R47))

#### Dependency and configuration updates:
* Updated `pyproject.toml` temporarily since `zkvyper` does not support `vyper>=0.4.2` (I'll go handle this).

#### Test updates:
* Adjusted test configurations to align with the refactored environment setup, including changes to the `zksync_sepolia_fork` fixture. (`tests/conftest.py`, [tests/conftest.pyL33-R35](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L33-R35))
* Updated call trace assertions in `test_boa_loads.py` to reflect changes in error messages and contract behavior. (`tests/test_boa_loads.py`, [tests/test_boa_loads.pyL134-R151](diffhunk://#diff-56405f1e0ee48e0f844d65ac4026abb44a3a31ee4bccbf069b6c6447899319efL134-R151))

### How to verify it
Run `make test` and see it all pass. You should have the latest anvil-zksync, and it should pass with the latest blocks.
You can also run `make lint` to be sure that the code complies.

### Description for the changelog

* Enhanced AnvilZKsync Management: implemented automatic cleanup of test nodes, enabled dynamic port allocation for parallel testing, and improved overall node startup/shutdown robustness.

* Streamlined zkSync Environment: refactored environment setup functions (set_zksync_env, set_zksync_fork, etc.) for clearer usage and updated forking defaults.

* Improved Forking Logic: enhanced fork and fork_rpc methods for better RPC connection handling and more reliable node setup.

* Dependency & Test Adjustments: included a temporary dependency fix for zkvyper and updated test configurations/assertions to match the new system.


### Cute Animal Picture
![image](https://github.com/user-attachments/assets/f572fe48-883e-412e-bed5-a1c823e47ac1)
